### PR TITLE
Add an API for stderr, rather than assuming os.Stderr

### DIFF
--- a/vcs_test.go
+++ b/vcs_test.go
@@ -177,7 +177,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got, err := repoRootForImportPath(test.path, web.SecureOnly)
+		got, err := repoRootForImportPath(test.path, web.SecureOnly, os.Stderr)
 		want := test.want
 
 		if want == nil {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/stderr:

cd2181dbb26e8f8088b221ce5f82fb89c4f4ba9a (2021-08-04 20:08:39 -0400)
Add an API for stderr, rather than assuming os.Stderr

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics