### PR TITLE
add the ability to checkout a ref

### DIFF
--- a/get.go
+++ b/get.go
@@ -138,6 +138,25 @@ func (d *Downloader) Download(pkg string) (string, error) {
 	return result, nil
 }
 
+// Update the checked out repo to the given ref.
+// Assumes the repo has already been downloaded.
+func (d *Downloader) RefSync(pkg, tag string) error {
+	srcRoot := d.srcRoot
+	_, rr, err := d.repoRoot(pkg)
+	if err != nil {
+		return err
+	}
+	vcs, rootPath := rr.vcs, rr.Root
+	root := filepath.Join(srcRoot, filepath.FromSlash(rootPath))
+	cmdCtx := newCmdContext(root, d.Stderr)
+	for _, cmd := range vcs.tagSyncCmd {
+		if err := vcs.run(cmdCtx, cmd, "tag", tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Determines where the repository will be downloaded before we download it.
 func (d *Downloader) DestinationPath(pkg string) string {
 	srcRoot := d.srcRoot

--- a/get_test.go
+++ b/get_test.go
@@ -39,6 +39,22 @@ func TestDestinationPath(t *testing.T) {
 	assert.True(t, strings.HasSuffix(result, "/github.com/tilt-dev/tilt-extensions/hello_world"))
 }
 
+func TestTagSync(t *testing.T) {
+	dir := setupDir(t)
+	dlr := NewDownloader(dir)
+	result, err := dlr.Download("github.com/tilt-dev/tilt-extensions")
+	require.NoError(t, err)
+
+	err = dlr.RefSync("github.com/tilt-dev/tilt-extensions",
+		"5670e8d8c5925981d019e6065a30058fc50eb299") // initial commit
+	require.NoError(t, err)
+
+	contents, err := ioutil.ReadFile(filepath.Join(result, "README.md"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "# tilt-extensions", string(contents))
+}
+
 func TestHeadRef(t *testing.T) {
 	dir := setupDir(t)
 	downloader := NewDownloader(dir)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ref:

5c99bc1bb72a02bb3cb1d85d29668ab258ba3682 (2021-08-04 20:38:49 -0400)
add the ability to checkout a ref

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics