### PR TITLE
vcs: fix `-go-internal-cd`

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -433,7 +433,8 @@ func (v *vcsCmd) run1(ctx cmdContext, cmdline string, keyval []string, verbose b
 	}
 
 	cmd := exec.Command(v.cmd, args...)
-	cmd.Dir = ctx.dir
+	// dir defaults to ctx.dir but will be overridden if the command starts with `-go-internal-cd`
+	cmd.Dir = dir
 	cmd.Env = envForDir(cmd.Dir, os.Environ())
 
 	out, err := cmd.Output()
@@ -443,7 +444,7 @@ func (v *vcsCmd) run1(ctx cmdContext, cmdline string, keyval []string, verbose b
 			if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
 				ctx.stderr.Write(ee.Stderr)
 			} else {
-				fmt.Fprintf(ctx.stderr, err.Error())
+				fmt.Fprintf(ctx.stderr, "%s\n", err.Error())
 			}
 		}
 	}


### PR DESCRIPTION
The command directory was always being overridden by the context
directory. This actually meant that some VCS commands were running
in the wrong place (e.g. doing a submodule update on the CWD rather
than the cloned repo).

Often, this wasn't noticeable because the CWD was _also_ a Git repo;
in fact, that's why tests didn't catch this since the `go-get` dir
is a Git repo. Tests now set the CWD to an empty tmpdir to avoid
this.