### PR TITLE
test: add a test for syncing to a v-number tag

### DIFF
--- a/get_test.go
+++ b/get_test.go
@@ -55,6 +55,21 @@ func TestTagSync(t *testing.T) {
 	assert.Equal(t, "# tilt-extensions", string(contents))
 }
 
+func TestVersionTagSync(t *testing.T) {
+	dir := setupDir(t)
+	dlr := NewDownloader(dir)
+	result, err := dlr.Download("github.com/tilt-dev/tilt-extensions")
+	require.NoError(t, err)
+
+	err = dlr.RefSync("github.com/tilt-dev/tilt-extensions", "v0.25.0")
+	require.NoError(t, err)
+
+	contents, err := ioutil.ReadFile(filepath.Join(result, "README.md"))
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(string(contents), "# Tilt Extensions"))
+}
+
 func TestHeadRef(t *testing.T) {
 	dir := setupDir(t)
 	downloader := NewDownloader(dir)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/sync:

4b6d96f6f19ee918bde76b7a9844459aaadc5216 (2022-02-18 08:57:20 -0500)
test: add a test for syncing to a v-number tag

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics