### PR TITLE
Adds VCS for Gitlab

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -822,6 +822,15 @@ var vcsPaths = []*vcsPath{
 		check:  noVCSSuffix,
 	},
 
+	// Gitlab
+	{
+		prefix: "gitlab.com/",
+		regexp: regexp.MustCompile(`^(?P<root>gitlab\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`),
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  noVCSSuffix,
+	},
+
 	// Bitbucket
 	{
 		prefix: "bitbucket.org/",

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -36,6 +36,13 @@ func TestRepoRootForImportPath(t *testing.T) {
 				Repo: "https://github.com/user/unicode",
 			},
 		},
+		{
+			"gitlab.com/gitlab-org/gitlab-terminal",
+			&repoRoot{
+				vcs:  vcsGit,
+				Repo: "https://gitlab.com/gitlab-org/gitlab-terminal",
+			},
+		},
 		// IBM DevOps Services tests
 		{
 			"hub.jazz.net/git/user1/pkgname",

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -28,6 +28,13 @@ func TestRepoRootForImportPath(t *testing.T) {
 				Repo: "https://github.com/golang/groupcache",
 			},
 		},
+		{
+			"github.com/tilt-dev/tilt-extensions",
+			&repoRoot{
+				vcs:  vcsGit,
+				Repo: "https://github.com/tilt-dev/tilt-extensions",
+			},
+		},
 		// Unicode letters in directories (issue 18660).
 		{
 			"github.com/user/unicode/испытание",
@@ -37,10 +44,10 @@ func TestRepoRootForImportPath(t *testing.T) {
 			},
 		},
 		{
-			"gitlab.com/gitlab-org/gitlab-terminal",
+			"gitlab.com/nicks6/tilt-extension-experiment",
 			&repoRoot{
 				vcs:  vcsGit,
-				Repo: "https://gitlab.com/gitlab-org/gitlab-terminal",
+				Repo: "https://gitlab.com/nicks6/tilt-extension-experiment",
 			},
 		},
 		// IBM DevOps Services tests


### PR DESCRIPTION
From https://github.com/tilt-dev/tilt/issues/5909#issuecomment-1361100423 - mentions that `gitlab.com` host/regex is missing.

After this PR, a version bump to `v0.2.3` and updating it in `tilt-dev/tilt` should resolve the original issue

## Testing from `tilt-dev/tilt`

With this branch checked out, in your `go.mod` replace `go-get` with a local path
```go.mod
module github.com/tilt-dev/tilt

go 1.19

replace github.com/tilt-dev/go-get => /path/to/this/local/go-get

require (
  // all of the things
)
```

Run a `go mod vendor` and then `make install`

<details>
  <summary><h2>Sample Tiltfile</h2></summary>

```Starlark
extension_path="https://gitlab.com/nicks6/tilt-extension-experiment"
v1alpha1.extension_repo(name='tilt-extension-experiment', url=extension_path, ref='main')
v1alpha1.extension(name='tilt_extension', repo_name='tilt-extension-experiment', repo_path='tilt_extension')
load('ext://tilt_extension', 'vue_build', 'dotnet_build')

vue_build("test")
test_yaml = blob("""---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  labels:
    app.kubernetes.io/name: test
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: test
    spec:
      containers:
        - name: test
          image: test:latest
""")
k8s_yaml(test_yaml)
```
</details>

`"$(go env GOPATH)/bin/tilt" up` should find and download the gitlab extension, run `vue_build("test")` and start a container