### PR TITLE
fix: support GitLab nested groups in repo root resolution

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -825,7 +825,7 @@ var vcsPaths = []*vcsPath{
 	// Gitlab
 	{
 		prefix: "gitlab.com/",
-		regexp: regexp.MustCompile(`^(?P<root>gitlab\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`),
+		regexp: regexp.MustCompile(`^(?P<root>gitlab\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+(/[A-Za-z0-9_.\-]+)*)$`),
 		vcs:    "git",
 		repo:   "https://{root}",
 		check:  noVCSSuffix,

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -50,6 +50,14 @@ func TestRepoRootForImportPath(t *testing.T) {
 				Repo: "https://gitlab.com/nicks6/tilt-extension-experiment",
 			},
 		},
+		// GitLab nested groups (issue tilt-dev/tilt#6352).
+		{
+			"gitlab.com/myorg/mygroup/mysubgroup/myproject",
+			&repoRoot{
+				vcs:  vcsGit,
+				Repo: "https://gitlab.com/myorg/mygroup/mysubgroup/myproject",
+			},
+		},
 		// IBM DevOps Services tests
 		{
 			"hub.jazz.net/git/user1/pkgname",


### PR DESCRIPTION
## Summary

Fixes the GitLab URL regex so that nested groups (e.g. `gitlab.com/org/group/subgroup/repo`) resolve correctly.

**Problem:** The current regex only captures the first two path segments (`gitlab.com/org/repo`) as the repo root. For GitLab nested groups, this points to a *group* instead of the actual *repo*, causing resolution failures.

**Fix:** Move the trailing path segment pattern *inside* the `root` capture group so the full nested path is treated as the repo root:

```diff
- ^(?P<root>gitlab\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$
+ ^(?P<root>gitlab\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+(/[A-Za-z0-9_.\-]+)*)$
```

A test case for a 4-level nested GitLab URL has been added to `TestRepoRootForImportPath`.

## Context

- Fixes tilt-dev/tilt#6352
- Originally submitted as tilt-dev/tilt#6713 (vendored copy), moved upstream per maintainer feedback

## Test plan

- [x] `TestRepoRootForImportPath` passes with new nested group test case
- [x] Existing GitLab and GitHub test cases still pass

> **Note:** `example_test.go` has a pre-existing build error on master (niladic `ExampleGet` function) unrelated to this change.